### PR TITLE
Adding DIB_APT_SOURCES_INLINE variable to apt-source element

### DIFF
--- a/elements/apt-sources/README.rst
+++ b/elements/apt-sources/README.rst
@@ -15,3 +15,16 @@ DIB_APT_SOURCES
     ``/etc/apt/sources.list``
   :Example: ``DIB_APT_SOURCES=/etc/apt/sources.list`` will use the same
     sources.list as the build host.
+
+DIB_APT_SOURCES_INLINE
+  :Required: No
+  :Default: None (Does not replace sources.list file)
+  :Description: Array of sources.list values to be used
+  :Example: B_APT_SOURCES_INLINE=(
+    "deb http://mirror.servers.com/debian/ jessie main contrib non-free"
+    "deb-src http://mirror.servers.com/debian/ jessie main contrib non-free"
+    )
+
+Note: You should use or DIB_APT_SOURCES or DIB_APT_SOURCES_INLINE, but not 
+the both same time.
+

--- a/elements/apt-sources/extra-data.d/99-override-default-apt-sources
+++ b/elements/apt-sources/extra-data.d/99-override-default-apt-sources
@@ -8,18 +8,37 @@ set -eu
 set -o pipefail
 
 # exit directly if DIB_APT_SOURCES is not defined properly
-if [ -z "${DIB_APT_SOURCES:-}" ] ; then
-    echo "DIB_APT_SOURCES must be set to the location of a sources.list file you wish to use"
+if [ -z "${DIB_APT_SOURCES:-}" -a -z "${DIB_APT_SOURCES_INLINE:-}" ] ; then
+    echo "DIB_APT_SOURCES must be set to the location of a sources.list file you wish to use or"
+    echo "DIB_APT_SOURCES_INLINE must be set to an array of the mirror strings"
     exit 0
-elif [ ! -f "$DIB_APT_SOURCES" -o ! -s "$DIB_APT_SOURCES" ] ; then
+elif [ -n "${DIB_APT_SOURCES:-}" -a ! -f "$DIB_APT_SOURCES" -o ! -s "$DIB_APT_SOURCES" ] ; then
     echo "$DIB_APT_SOURCES  is not a valid sources.list file."
     echo "You should assign proper sources.list file in DIB_APT_SOURCES"
     exit 1
 fi
+if [ -n "${DIB_APT_SOURCES:-}" ]; then
 
-DIB_APT_SOURCES=`readlink -f $DIB_APT_SOURCES`
+    DIB_APT_SOURCES=`readlink -f $DIB_APT_SOURCES`
 
-# copy the sources.list to cloudimg
-pushd $TMP_MOUNT_PATH/etc/apt/
-sudo cp -f $DIB_APT_SOURCES sources.list
-popd
+    # copy the sources.list to cloudimg
+    pushd $TMP_MOUNT_PATH/etc/apt/
+    sudo cp -f $DIB_APT_SOURCES sources.list
+    popd
+elif [ -n "${DIB_APT_SOURCES_INLINE:-}" ]; then
+
+    # replace sources.list with content of the array DIB_APT_SOURCES_INLINE, one element per line
+    if [ -f $TMP_MOUNT_PATH/etc/apt/sources.list ];
+    then
+        rm -f $TMP_MOUNT_PATH/etc/apt/sources.list
+    fi
+    for index in `seq 0 ${#DIB_APT_SOURCES_INLINE[*]}`;
+    do
+        echo adding ${DIB_APT_SOURCES_INLINE[index]} to sources.list
+        echo ${DIB_APT_SOURCES_INLINE[index]} >> $TMP_MOUNT_PATH/etc/apt/sources.list
+    done
+else
+    echo "No DIB_APT_SOURCES or DIB_APT_SOURCES_INLINE is defined"
+    exit -1
+fi
+exit 0


### PR DESCRIPTION
Currenlty apt-source require absolute path to the new sources.list file. This is not very portable, especially when apt-source element is used inside other element via element-deps.

sources.list usually very small and can easily be fitted in the environment variable.

I've modified apt-source to accept or DIB_APT_SOURCE (as it was before) or to accept DIB_APT_SOURCE_INLINE (array of lines corresponding to the new sources.list).
